### PR TITLE
Update RBAC permissions to approve certificates on Kubernetes 1.18

### DIFF
--- a/k8s/k8s-seeds/seed.yml
+++ b/k8s/k8s-seeds/seed.yml
@@ -166,21 +166,37 @@ kind: ClusterRole
 metadata:
   name: permission-manager-cluster-role
 rules:
-  - apiGroups:
-      - "*"
+  # Allow full management of all the Permission Manager resources
+  - apiGroups: [ "permissionmanager.user" ]
     resources:
-      - "permissionmanagerusers"
+      - "*"
+    verbs: [ "get", "list", "create", "update", "delete", "watch" ]
+  # Allow full management of the RBAC resources
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
       - "clusterrolebindings"
       - "clusterroles"
       - "rolebindings"
       - "roles"
+    verbs: [ "get", "list", "create", "update", "delete", "watch" ]
+  # Allow full management of certificates CSR, including their approval
+  - apiGroups: [ "certificates.k8s.io" ]
+    resources:
       - "certificatesigningrequests"
       - "certificatesigningrequests/approval"
-    verbs:
-      - "*"
-
-  - apiGroups:
-      - ""
+    verbs: [ "get", "list", "create", "update", "delete", "watch" ]
+  # Support legacy versions, before signerName was added
+  # (see https://github.com/kubernetes/kubernetes/pull/88246)
+  - apiGroups: [ "certificates.k8s.io" ]
+    resources:
+      - "signers"
+    resourceNames:
+      - "kubernetes.io/legacy-unknown"
+      - "kubernetes.io/kube-apiserver-client"
+    verbs: [ "approve" ]
+  # Allow to get and list Namespaces
+  - apiGroups: [ "" ]
     resources:
       - "namespaces"
-    verbs: ["get", "list"]
+    verbs: [ "get", "list" ]


### PR DESCRIPTION
This PR fixes #21 and fixes #17 adding explicit support to the breaking changes done to the `certificates.k8s.io` in https://github.com/kubernetes/kubernetes/pull/88246

The RBAC permissions for permission-manager now require to explicitly set the approve permission for certificates where the signer is not specified.

```yaml
  - apiGroups: ["certificates.k8s.io"]
    resources:
      - "signers"
    resourceNames:
    - "kubernetes.io/legacy-unknown"
    - "kubernetes.io/kube-apiserver-client"
    verbs: [ "approve" ]
```

See as a reference https://github.com/istio/istio/pull/22084.

The PR has been tested on both Kubernetes 1.18.2

```
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.2", GitCommit:"52c56ce7a8272c798dbc29846288d7cd9fbae032", GitTreeState:"clean", BuildDate:"2020-04-16T23:34:25Z", GoVersion:"go1.14.2", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.2", GitCommit:"52c56ce7a8272c798dbc29846288d7cd9fbae032", GitTreeState:"clean", BuildDate:"2020-04-28T05:35:31Z", GoVersion:"go1.13.9", Compiler:"gc", Platform:"linux/amd64"}
```

and Kubernetes 1.17.5

```
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.2", GitCommit:"52c56ce7a8272c798dbc29846288d7cd9fbae032", GitTreeState:"clean", BuildDate:"2020-04-16T23:34:25Z", GoVersion:"go1.14.2", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.5", GitCommit:"e0fccafd69541e3750d460ba0f9743b90336f24f", GitTreeState:"clean", BuildDate:"2020-05-01T02:11:15Z", GoVersion:"go1.13.9", Compiler:"gc", Platform:"linux/amd64"}
```