### PR TITLE
Update the contributors documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,61 +1,41 @@
-run: 
-	go run main.go
+# run permission-manager
+run:
+	go run cmd/run-server.go
 
-copy-kind-ca-crt:
-	docker cp kind-control-plane:/etc/kubernetes/pki/ca.crt ~/.kind/ca.crt
-
-
-make gotest:
+# execute go tests
+gotest:
 	go test sighupio/permission-manager/...
 
+# execute e2e tests
+e2e:
+	cd e2e-test && yarn test
 
-seed-cluster:
+# compile the UI to a static go file
+build-ui:
+	rm -r statik
+	rm -r ./web-client/build
+	npm run build --prefix ./web-client 
+	statik -src=./web-client/build
+
+
+# apply to the cluster the test manifests
+manifests-dev:
 	kubectl apply -f k8s/k8s-seeds/namespace.yml
 	kubectl apply -f k8s/k8s-seeds
 	kubectl apply -f k8s/test-manifests
 
-seed-cluster-production:
-	kubectl apply -f k8s/k8s-seeds/namespace.yml
-	kubectl apply -f k8s/k8s-seeds
 
-dev-kind:
-	$(MAKE) copy-kind-ca-crt
-	CA_CRT_PATH=~/.kind/ca.crt \
-	CLUSTER_NAME=local-kind-development \
-	CONTROL_PLANE_ADDRESS=https://127.0.0.1:62183 \
+# run permission-manager using Kind
+kind: kind-cluster manifests kind-run
+
+# create a local Kind cluster
+kind-cluster:
+	kind create cluster --name permission-manager-dev --config hack/kind-config.yaml -q || true
+
+# run and connect permission-manager to the local Kind cluster
+kind-run:
+	CLUSTER_NAME=kind-permission-manager-dev \
+	CONTROL_PLANE_ADDRESS=https://127.0.0.1:61999 \
 	BASIC_AUTH_PASSWORD=secret \
 	PORT=4000 \
-	gomon cmd/run-server.go
-
-
-dev-minikube:
-	CA_CRT_PATH=~/.minikube/ca.crt \
-	CLUSTER_NAME=local-minikube-development \
-	CONTROL_PLANE_ADDRESS=https://192.168.64.35:8443 \
-	BASIC_AUTH_PASSWORD=secret \
-	PORT=4000 \
-	gomon cmd/run-server.go
-
-
-
-e2e:
-	cd e2e-test && yarn test
-	
-
-build-ui:
-	rm -r statik
-	rm -r ./web-client/build
-
-	npm run build --prefix ./web-client 
-	statik -src=./web-client/build
-
-delete-users:
-	kubectl delete -f ./crd/user-crd-definition.yml && kubectl apply -f ./crd/user-crd-definition.yml
-
-release-image:
-	docker build -t reg.sighup.io/sighup-products/permission-manager:1.0.0 .
-	docker push reg.sighup.io/sighup-products/permission-manager:1.0.0
-	
-forward-service:
-	kubectl port-forward svc/permission-manager-service 4000 --namespace permission-manager	
-
+	go run cmd/run-server.go

--- a/hack/kind-config.yaml
+++ b/hack/kind-config.yaml
@@ -1,0 +1,12 @@
+---
+
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    image: kindest/node:v1.17.5
+networking:
+  # Use a fixed port for the API server instead of
+  # a random one
+  apiServerAddress: "127.0.0.1"
+  apiServerPort: 61999


### PR DESCRIPTION
While developing #27 I've took the chance of updating the project Makefile and how-to-contribute.md document.

The major change consists in the fact that Kind is now used as default development environment, this because via the `hack/kind-config.yaml` it is possible to fix the K8s api-server bind address making the configuration working the same in any environment.