### PR TITLE
FIX: missing bind permission

### DIFF
--- a/k8s/k8s-seeds/seed.yml
+++ b/k8s/k8s-seeds/seed.yml
@@ -179,7 +179,7 @@ rules:
       - "clusterroles"
       - "rolebindings"
       - "roles"
-    verbs: [ "get", "list", "create", "update", "delete", "watch" ]
+    verbs: [ "get", "list", "create", "update", "delete", "bind", "watch" ]
   # Allow full management of certificates CSR, including their approval
   - apiGroups: [ "certificates.k8s.io" ]
     resources:


### PR DESCRIPTION
Hi team!

After merging #25 the RBAC required permission by permission-manager got an error.

This caused:

- `rolebindings` and `clusterrolebindings` can not be created by permission-manager.
- the "user" is created but... the UI (frontend) can not show details about it if was created with this issue.

According to: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#restrictions-on-role-binding-creation-or-update

If permission-manager want to grant permissions (yes), it should have explicitly the "bind" verb.

Thanks!