### PR TITLE
Add namespace to kubeconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea
 permission-manager
 e2e-test/data/kubeconfigs
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 permission-manager
 e2e-test/data/kubeconfigs
 node_modules

--- a/internal/kubeconfig/create-kubeconfig.go
+++ b/internal/kubeconfig/create-kubeconfig.go
@@ -7,12 +7,12 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func CreateKubeconfigYAMLForUser(ctx context.Context, kc kubernetes.Interface, clusterName, clusterControlPlaceAddress, username string) (kubeconfigYAML string) {
-	return createKubeconfig(clusterName, username, clusterControlPlaceAddress, getCaBase64(), getServiceAccountToken(ctx, kc, username))
+func CreateKubeconfigYAMLForUser(ctx context.Context, kc kubernetes.Interface, clusterName, clusterControlPlaceAddress, username string, namespace string) (kubeconfigYAML string) {
+	return createKubeconfig(clusterName, username, namespace, clusterControlPlaceAddress, getCaBase64(), getServiceAccountToken(ctx, kc, username))
 }
 
 // CreateKubeconfigYAML returns a kubeconfig YAML string
-func createKubeconfig(clusterName, username, clusterControlPlaceAddress, caBasebase64, token string) (kubeconfigYAML string) {
+func createKubeconfig(clusterName, username, namespace, clusterControlPlaceAddress, caBasebase64, token string) (kubeconfigYAML string) {
 	certificate_tpl := `---
 apiVersion: v1
 kind: Config
@@ -26,6 +26,7 @@ contexts:
   - context:
       cluster: %s
       user: %s
+      namespace: %s
     name: %s@%s
 users:
   - name: %s
@@ -40,6 +41,7 @@ users:
 		clusterName,
 		clusterName,
 		username,
+		namespace,
 		username,
 		clusterName,
 		username,

--- a/internal/kubeconfig/create-kubeconfig_test.go
+++ b/internal/kubeconfig/create-kubeconfig_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestCreateKubeconfig(t *testing.T) {
-	got := createKubeconfig("My-cluster", "gino", "https://100.200.10.200", "CA_BASE64", "TOKEN")
+	got := createKubeconfig("My-cluster", "gino", "pangolier", "https://100.200.10.200", "CA_BASE64", "TOKEN")
 
 	want := `---
 apiVersion: v1
@@ -22,6 +22,7 @@ contexts:
   - context:
       cluster: My-cluster
       user: gino
+      namespace: pangolier
     name: gino@My-cluster
 users:
   - name: gino

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -311,7 +311,8 @@ func deleteRolebinding(c echo.Context) error {
 
 func createKubeconfig(clusterName, clusterControlPlaceAddress string) echo.HandlerFunc {
 	type Request struct {
-		Username string `json:"username"`
+		Username  string `json:"username"`
+		Namespace string `json:"namespace"`
 	}
 	type Response struct {
 		Ok         bool   `json:"ok"`
@@ -324,7 +325,7 @@ func createKubeconfig(clusterName, clusterControlPlaceAddress string) echo.Handl
 			return err
 		}
 
-		kubeCfg := kubeconfig.CreateKubeconfigYAMLForUser(c.Request().Context(), ac.Kubeclient, clusterName, clusterControlPlaceAddress, r.Username)
+		kubeCfg := kubeconfig.CreateKubeconfigYAMLForUser(c.Request().Context(), ac.Kubeclient, clusterName, clusterControlPlaceAddress, r.Username, r.Namespace)
 
 		return c.JSON(http.StatusOK, Response{Ok: true, Kubeconfig: kubeCfg})
 	}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -325,6 +325,12 @@ func createKubeconfig(clusterName, clusterControlPlaceAddress string) echo.Handl
 			return err
 		}
 
+		//required to make the API backward-compatible. Initially the API had only the username parameter
+		//this allows gradual migration of clients/scrips/e2e-tests that assume the request has only username parameter
+		if r.Namespace == "" {
+			r.Namespace = "default"
+		}
+
 		kubeCfg := kubeconfig.CreateKubeconfigYAMLForUser(c.Request().Context(), ac.Kubeclient, clusterName, clusterControlPlaceAddress, r.Username, r.Namespace)
 
 		return c.JSON(http.StatusOK, Response{Ok: true, Kubeconfig: kubeCfg})

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -325,8 +325,7 @@ func createKubeconfig(clusterName, clusterControlPlaceAddress string) echo.Handl
 			return err
 		}
 
-		//required to make the API backward-compatible. Initially the API had only the username parameter
-		//this allows gradual migration of clients/scrips/e2e-tests that assume the request has only username parameter
+		// if no namespace is set we set the value "default"
 		if r.Namespace == "" {
 			r.Namespace = "default"
 		}

--- a/web-client/src/components/CreateKubeconfigButton.js
+++ b/web-client/src/components/CreateKubeconfigButton.js
@@ -5,7 +5,13 @@ import Editor from 'react-simple-code-editor'
 import {useRbac} from "../hooks/useRbac";
 import {extractUsersRoles} from "../services/role";
 
-// we extract the valid kubeconfig namespace values
+/**
+ * Extracts the valid kubeconfig namespace values
+ * @param {array} roleBindings
+ * @param {array} clusterRoleBindings
+ * @param {object} user
+ * @returns {*[]}
+ */
 function getValidNamespaces(roleBindings, clusterRoleBindings, user) {
     const {extractedPairItems} = extractUsersRoles(roleBindings, clusterRoleBindings, user.name);
 
@@ -14,10 +20,7 @@ function getValidNamespaces(roleBindings, clusterRoleBindings, user) {
     // we remove the invalid namespaces from the array
     const validNamespaces = uniqueNamespaces.filter(i => i !== "ALL_NAMESPACES");
 
-    //a) If no elements are present we add the default namespace to the extracted namespaces. This is done to ensure backwards compatibility
-    //   in the application logic and avoid crashes in the case no namespace is present.
-    //   Default namespace ___SHOULD___ be already used implicitly by kubeconfig if the namespace is not defined
-    //   (that would mean it isn't a breaking change)
+    //a) If no elements are present we add the default namespace to the extracted namespaces.
     if (validNamespaces.length === 0) {
         validNamespaces.push("default");
     }

--- a/web-client/src/components/CreateKubeconfigButton.js
+++ b/web-client/src/components/CreateKubeconfigButton.js
@@ -12,7 +12,7 @@ export default function CreateKubeconfigButton({ user }) {
     if (showModal && kubeconfig === '') {
       axios
         .post('/api/create-kubeconfig', {
-          username: user.name
+          username: user.name, namespace: "default"
         })
         .then(({ data }) => {
           setKubeconfig(data.kubeconfig)

--- a/web-client/src/components/CreateKubeconfigButton.js
+++ b/web-client/src/components/CreateKubeconfigButton.js
@@ -36,7 +36,7 @@ export default function CreateKubeconfigButton({ user }) {
 
   useEffect(() => {
     // !kubeconfig.includes(chosenNamespace) is needed to remake the API request if the chosenNamespace changed
-    if (showModal && (kubeconfig === '' || !kubeconfig.includes(chosenNamespace))) {
+    if (showModal && (kubeconfig === '' || !kubeconfig.includes("namespace: " + chosenNamespace))) {
       axios
         .post('/api/create-kubeconfig', {
           username: user.name, namespace: chosenNamespace

--- a/web-client/src/services/role.js
+++ b/web-client/src/services/role.js
@@ -1,7 +1,12 @@
 import {templateClusterResourceRolePrefix} from "../constants";
 import uuid from "uuid";
 
-// A function that encapsulates the common logic to extract the roles of a given user
+/**
+ * A function that encapsulates the common logic to extract the roles of a given user
+ * @param {array} roleBindings
+ * @param {array} clusterRoleBindings
+ * @param {string} username the name of the user
+ */
 export function extractUsersRoles(roleBindings, clusterRoleBindings, username) {
     const rbs = (roleBindings || []).filter(rb => {
         return rb.metadata.name.startsWith(username)

--- a/web-client/src/services/role.js
+++ b/web-client/src/services/role.js
@@ -1,0 +1,50 @@
+import {templateClusterResourceRolePrefix} from "../constants";
+import uuid from "uuid";
+
+// A function that encapsulates the common logic to extract the roles of a given user
+export function extractUsersRoles(roleBindings, clusterRoleBindings, username) {
+    const rbs = (roleBindings || []).filter(rb => {
+        return rb.metadata.name.startsWith(username)
+    })
+
+    const crbs = (clusterRoleBindings || []).filter(crb => {
+        return crb.metadata.name.startsWith(username)
+    })
+
+    const pairs = [...rbs, ...crbs]
+        .filter(
+            crb => !crb.metadata.name.includes(templateClusterResourceRolePrefix)
+        )
+        .map(v => {
+            const name = v.metadata.name
+            const template = v.roleRef.name
+            const namespace = v.metadata.namespace || 'ALL_NAMESPACES'
+            return {template, namespace, name}
+        })
+
+    const extractedPairItems = pairs.reduce((acc, item) => {
+        const has = acc.find(x => x.template === item.template)
+
+        if (has) {
+            if (has.namespaces !== 'ALL_NAMESPACES') {
+                if (item.namespace === 'ALL_NAMESPACES') {
+                    has.namespaces = 'ALL_NAMESPACES'
+                } else {
+                    has.namespaces.push(item.namespace)
+                }
+            }
+        } else {
+            acc.push({
+                id: uuid.v4(),
+                namespaces:
+                    item.namespace === 'ALL_NAMESPACES'
+                        ? 'ALL_NAMESPACES'
+                        : [item.namespace],
+                template: item.template
+            })
+        }
+
+        return acc
+    }, [])
+    return {rbs, crbs, extractedPairItems};
+}


### PR DESCRIPTION
Hello Everyone!

This PR aims to close #29.

Cliff notes:

Backend:

a) adds the support for namespace parameter in the /create-kubeconfig endpoint. For backwards compatibility if no namespace value is set it defaults to "default". This allows the gradual migration of tests/other-usages.

b) adds the namespace parameter in createKubeconfig function and related calls

Frontend:

a) extracted the logic that pairs roles to an user from EditUser in a function called extractUsersRoles. It allow us to reuse the logic within the frontend

b) CreateKubeconfigButton Component now has a select dropdown. It is populated with the namespaces that an user has access to. The selected value of the dropdown will be passed along the name to the /create-kubeconfig endpoint

Some notes: 

To avoid breaking changes in the frontend code if the user has access to no namespace the drop down is populated with "default" value. This is also coherent with the already generated kubeconfig behavior (if no namespace is selected kubectl tries to talk to default namespace)

If the user has access to ALL_NAMESPACES it gets replace with "default" namespace. This approach seems the most coherent with the already existing codebase. See extractUsersRoles





