### PR TITLE
dynamic e2e tests

### DIFF
--- a/development/e2e-up.sh
+++ b/development/e2e-up.sh
@@ -5,7 +5,11 @@ kind create cluster --config=./development/kind-config.yml --kubeconfig=./.kubec
 
 source .env-cluster
 
-bats -t tests/setup.sh && bats -t tests/create-user.sh
+export IS_LOCAL=TRUE
+
+bats -t tests/setup.sh
+
+bats -t tests/create-user.sh
 
 sleep 5
 

--- a/development/e2e-up.sh
+++ b/development/e2e-up.sh
@@ -5,8 +5,6 @@ kind create cluster --config=./development/kind-config.yml --kubeconfig=./.kubec
 
 source .env-cluster
 
-export IS_LOCAL=TRUE
-
 bats -t tests/setup.sh
 
 bats -t tests/create-user.sh

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -25,9 +25,11 @@ load "./lib/helper"
     info
 
     deploy(){
-        # todo it uses static version manifests?
-        kubectl apply -f deployments/kubernetes/deploy.yml
-        kubectl wait --for=condition=Available deploy/permission-manager -n permission-manager --timeout=300s
+      # we build the permission image from the current data and run the tests against it
+      make build
+      make deploy
+      kubectl wait --for=condition=Available deploy/permission-manager -n permission-manager --timeout=300s
+
     }
 
     run deploy


### PR DESCRIPTION
Hello this PR fixes #52.

Now setup.sh deploy test does several things:

a) build a docker image with the repository
b) load the image into the kind cluster
c) deploy the permission manager with the image built from the step a)
d) run tests against it

Feel free to merge if everything is OK