### PR TITLE
Update CustomResourceDefinition to apiextensions.k8s.io/v1

### DIFF
--- a/deployments/kubernetes/deploy.yml
+++ b/deployments/kubernetes/deploy.yml
@@ -90,7 +90,7 @@ rules:
       - "namespaces"
     verbs: [ "get", "list" ]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: permission-manager

--- a/deployments/kubernetes/seeds/crd.yml
+++ b/deployments/kubernetes/seeds/crd.yml
@@ -1,22 +1,25 @@
-apiVersion: "apiextensions.k8s.io/v1beta1"
+apiVersion: "apiextensions.k8s.io/v1"
 kind: "CustomResourceDefinition"
 metadata:
   name: "permissionmanagerusers.permissionmanager.user"
 spec:
   group: "permissionmanager.user"
-  version: "v1alpha1"
+  versions: 
+    - name: "v1alpha1"
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                name:
+                  type: string
+                  minLength: 2
   scope: "Cluster"
   names:
     plural: "permissionmanagerusers"
     singular: "permissionmanageruser"
-    kind: "Permissionmanageruser"
-  validation:
-    openAPIV3Schema:
-      required: ["spec"]
-      properties:
-        spec:
-          required: ["name"]
-          properties:
-            name:
-              type: "string"
-              minimum: 2
+    kind: "Permissionmanageruser"    

--- a/helm_chart/Chart.yaml
+++ b/helm_chart/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.0-rc4
+version: 1.7.0-rc3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.7.0-rc4
+appVersion: 1.7.0-rc3

--- a/helm_chart/Chart.yaml
+++ b/helm_chart/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.0-rc3
+version: 1.7.0-rc4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.7.0-rc3
+appVersion: 1.7.0-rc4

--- a/helm_chart/templates/ClusterRoleBinding.yaml
+++ b/helm_chart/templates/ClusterRoleBinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "permission-manager.serviceAccountName" . }}

--- a/helm_chart/templates/crd.yml
+++ b/helm_chart/templates/crd.yml
@@ -1,22 +1,25 @@
-apiVersion: "apiextensions.k8s.io/v1beta1"
+apiVersion: "apiextensions.k8s.io/v1"
 kind: "CustomResourceDefinition"
 metadata:
   name: "permissionmanagerusers.permissionmanager.user"
 spec:
   group: "permissionmanager.user"
-  version: "v1alpha1"
+  versions: 
+    - name: "v1alpha1"
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                name:
+                  type: string
+                  minLength: 2
   scope: "Cluster"
   names:
     plural: "permissionmanagerusers"
     singular: "permissionmanageruser"
-    kind: "Permissionmanageruser"
-  validation:
-    openAPIV3Schema:
-      required: ["spec"]
-      properties:
-        spec:
-          required: ["name"]
-          properties:
-            name:
-              type: "string"
-              minimum: 2
+    kind: "Permissionmanageruser"    


### PR DESCRIPTION
As pointed out in https://github.com/sighupio/permission-manager/issues/71 our current manifests are not compatible with Kubernetes v1.22.

This PR updates the manifests to be compliant with Kubernetes v1.22.