### PR TITLE
Align regex an error messages/place holders for the username

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -88,8 +88,8 @@ trigger:
     include:
       - refs/heads/master
       - refs/tags/**
-      - refs/heads/dependabot/*
-      - refs/heads/renovate/*
+      - refs/heads/dependabot/**
+      - refs/heads/renovate/**
 
 environment:
   KIND_VERSION: v0.11.1
@@ -168,8 +168,8 @@ trigger:
     include:
       - refs/heads/master
       - refs/tags/**
-      - refs/heads/dependabot/*
-      - refs/heads/renovate/*
+      - refs/heads/dependabot/**
+      - refs/heads/renovate/**
 
 environment:
   KIND_VERSION: v0.11.1
@@ -248,8 +248,8 @@ trigger:
     include:
       - refs/heads/master
       - refs/tags/**
-      - refs/heads/dependabot/*
-      - refs/heads/renovate/*
+      - refs/heads/dependabot/**
+      - refs/heads/renovate/**
 
 environment:
   KIND_VERSION: v0.11.1

--- a/web-client/src/components/new-user-wizard.tsx
+++ b/web-client/src/components/new-user-wizard.tsx
@@ -37,8 +37,8 @@ export default function NewUserWizard() {
     }
     
     if (
-      !username.match(/^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$/)) {
-      setUsernameError(`user can only contain lowercase letters, dots, dashes and numbers`)
+      !username.match(/^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/)) {
+      setUsernameError(`username must be DNS-1123 compliant, it must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'jane.doe')`)
       return false
     }
     
@@ -127,7 +127,7 @@ export default function NewUserWizard() {
               Username
               <input
                 autoFocus
-                placeholder="Jane Doe"
+                placeholder="jane.doe"
                 className={`appearance-none block w-full  text-gray-700 border  rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white ${
                   usernameError && formTouched ? 'border-red-500' : ''
                 }`}


### PR DESCRIPTION
This PR tries to solve #73 

What I did here is:

1. Align the regex patter with the one available in the backend
2. Set the same error message like the one set in the backend
3. Change the placeholder for a valid one.

Also i've fixed a problem with the triggers for the dependand bot and renovate one