### PR TITLE
fix: The cluster resources option doesn't show its value

### DIFF
--- a/e2e-test/cypress/integration/permission-manager_spec.js
+++ b/e2e-test/cypress/integration/permission-manager_spec.js
@@ -82,3 +82,71 @@ it("Create use and save kubeconfig YAML to disk", function() {
       cy.writeFile(`data/kubeconfigs/${username}`, kubeconfigYAML);
     });
 });
+
+// This test covers this issue https://github.com/sighupio/permission-manager/issues/78
+it("Cluster resources after save check", () => {
+  /* SETUP */
+  const templateName = "developer";
+  const username = `test-user-${templateName}-${Date.now()}-2`;
+
+
+  /* INDEX PAGE */
+  //todo hardcoded password coming from the tests folder
+  cy.visit("http://admin:1v2d1e2e67dS@localhost:4000");
+
+  cy.contains(/create new user/i).click();
+
+  /* USER CREATION PAGE */
+  cy.url().should("include", "/new-user");
+
+  cy.queryByTestId("summmary").should("not.exist");
+
+  cy.findByLabelText(/username/i)
+      .type(username)
+      .should("have.value", username);
+
+  cy.findByText(/add/i).should("be.disabled");
+
+  cy.findByText(/save/i).should("be.disabled");
+
+  cy.findByTestId("template-select")
+      .findByText(templateName)
+      .should("exist");
+
+  cy.get("[class$=-control]")
+      .eq(1)
+      .click(0, 0, { force: true });
+
+  cy.findByTestId("namespaces-select")
+      .get("[class$=-option]")
+      .contains("default")
+      .click({ force: true });
+
+  cy.findByTestId("namespaces-select")
+      .get(".css-12jo7m5") /* the tag of selected item */
+      .contains("default");
+
+  cy.findByTestId("nonnamespaced-select")
+      .findByText("read-only")
+      .click({force: true})
+
+  cy.findByLabelText("read-only").should("be.checked");
+
+  cy.findByText(/add/i).should("not.be.disabled");
+
+  cy.findByText(/save/i).should("not.be.disabled");
+
+  cy.get("[data-testid=summary]").should("exist");
+
+  cy.findByText(/save/i).click();
+
+  cy.url().should("include", "/users/" + username);
+
+  cy.findByTestId("username-heading").should("have.text", username);
+
+  cy.contains('a', 'users').click();
+
+  cy.contains('a', username).click();
+
+  cy.findByLabelText("read-only").should("be.checked");
+})

--- a/web-client/src/components/ClusterAccessRadio.tsx
+++ b/web-client/src/components/ClusterAccessRadio.tsx
@@ -9,7 +9,7 @@ interface ClusterAccessRadioParameters {
 export default function ClusterAccessRadio({clusterAccess, setClusterAccess}: ClusterAccessRadioParameters) {
   return (
     <div>
-      <div>
+      <div data-testid="nonnamespaced-select">
         <div className="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2">
           access to cluster resouces (non-namespaced):
         </div>

--- a/web-client/src/components/edit-user.tsx
+++ b/web-client/src/components/edit-user.tsx
@@ -50,7 +50,7 @@ export default function EditUser({user}: EditUserParameters) {
   const {rbs, crbs, extractedPairItems} = extractUsersRoles(roleBindings, clusterRoleBindings, username);
   const [clusterAccess, setClusterAccess] = useState<ClusterAccess>('none')
   const [initialClusterAccess, setInitialClusterAccess] = useState<ClusterAccess>(null)
-  const [aggregatedRoleBindings, setAggregatedRoleBindings] = useState(extractedPairItems)
+  const [aggregatedRoleBindings, setAggregatedRoleBindings] = useState([])
   
   useEffect(() => {
     


### PR DESCRIPTION
fixes #78 

added also e2e test coverage on this issue to prevent regressions;

The problem was caching of RBAC data, creating a conflict with lines 57-60 of edit-user.tsx