### PR TITLE
fix: Kubeconfig in UI missing certificate-authority-data value

### DIFF
--- a/internal/resources/certificate.go
+++ b/internal/resources/certificate.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"encoding/base64"
+	"io/ioutil"
 	"log"
 	runtime "sigs.k8s.io/controller-runtime"
 )
@@ -15,6 +16,15 @@ func getCaBase64() string {
 		log.Fatalf("Unable to get kubeconfig.\n%v", err)
 	}
 
-	return base64.StdEncoding.EncodeToString(kConfig.CAData)
+	if len(kConfig.CAData) != 0 {
+		return base64.StdEncoding.EncodeToString(kConfig.CAData)
+	}
 
+	// CAData len can be 0, so as a fallback we read from CAFile
+	CAData, err := ioutil.ReadFile(kConfig.CAFile)
+	if err != nil {
+		log.Fatalf("Unable to read kubeconfig file.\n%v", err)
+	}
+
+	return base64.StdEncoding.EncodeToString(CAData)
 }


### PR DESCRIPTION
fixes #89

this bug was introduced in version v1.7.1-rc1, the string from CAData can be empty at times and in the previous version a fallback to CAFile was present, so I just reintroduced it.

This branch is taken from the commit 1ba5bcf9f3cf3bdeddfe2789c7659c3fd3095df6 so we can tag it as v1.7.2 (in branch fix-issue-89) without getting all the fixes scheduled for version 2.0.0