### PR TITLE
fix-cert-and-token

### DIFF
--- a/internal/resources/secrets.go
+++ b/internal/resources/secrets.go
@@ -5,7 +5,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-
 func (r *Manager) SecretGet(namespace, name string) (*v1.Secret, error) {
 	return r.kubeclient.CoreV1().Secrets(namespace).Get(r.context, name, metav1.GetOptions{})
+}
+
+func (r *Manager) SecretCreate(namespace string, secret *v1.Secret) (*v1.Secret, error) {
+	return r.kubeclient.CoreV1().Secrets(namespace).Create(r.context, secret, metav1.CreateOptions{})
 }


### PR DESCRIPTION
Hey, this `permission manager` is extremely useful tool! It really made life easy.
However, it seems to have issue generate token and cert. (Not sure if anyone else also experienced the same but it will just got stuck after I clicked on the `show kubeconfig` button.)
I've made some changes that will fix the issue.

Also, I  made a change to the workflow, so instead generate token from the service account, a `Secret` with type `
kubernetes.io/service-account-token` will be created.
In this way, user can trace how many tokens have been issued and invalidate any token anytime they want to.

